### PR TITLE
Ensure valid closed range is constructed from reported source positions

### DIFF
--- a/Sources/CommonMark/Nodes/Node.swift
+++ b/Sources/CommonMark/Nodes/Node.swift
@@ -98,7 +98,7 @@ open class Node {
     /// The line and column range of the element in the document.
     public var range: ClosedRange<Document.Position> {
         let start = Document.Position(line: numericCast(cmark_node_get_start_line(cmark_node)), column: numericCast(cmark_node_get_start_column(cmark_node)))
-        let end = Document.Position(line: numericCast(cmark_node_get_end_line(cmark_node)), column: numericCast(cmark_node_get_end_column(cmark_node)))
+        let end = Document.Position(line: max(start.line, numericCast(cmark_node_get_end_line(cmark_node))), column: max(start.column, numericCast(cmark_node_get_end_column(cmark_node))))
 
         return start...end
     }

--- a/Tests/CommonMarkTests/DocumentParsingTests.swift
+++ b/Tests/CommonMarkTests/DocumentParsingTests.swift
@@ -30,6 +30,21 @@ final class DocumentParsingTests: XCTestCase {
         XCTAssertEqual(paragraph.range.upperBound.column, 62)
     }
 
+    // https://github.com/SwiftDocOrg/CommonMark/issues/1
+    func testInvalidRange() throws {
+        let commonmark = "* #"
+
+        let document = try Document(commonmark)
+
+        let list = document.children.first as! List
+        let item = list.children.first! as List.Item
+        let heading = item.children.first as! Heading
+        XCTAssertEqual(heading.range.lowerBound.line, 1)
+        XCTAssertEqual(heading.range.lowerBound.column, 3)
+        XCTAssertEqual(heading.range.upperBound.line, 1)
+        XCTAssertEqual(heading.range.upperBound.column, 3)
+    }
+
     static var allTests = [
         ("testDocumentParsing", testDocumentParsing),
     ]


### PR DESCRIPTION
Resolves #1 until the underlying problem is fixed in [cmark](https://github.com/commonmark/cmark).

