### PR TITLE
Rename HTML to RawHTML

### DIFF
--- a/Sources/CommonMark/Nodes/Inline/RawHTML.swift
+++ b/Sources/CommonMark/Nodes/Inline/RawHTML.swift
@@ -13,7 +13,7 @@ import cmark
  > Tag and attribute names are not limited to current HTML tags,
  > so custom tags (and even, say, DocBook tags) may be used.
 */
-public final class HTML: Node {
+public final class RawHTML: Node {
     public override class var cmark_node_type: cmark_node_type { return CMARK_NODE_HTML_INLINE }
 
     public convenience init(literal: String?) {

--- a/Sources/CommonMark/Nodes/Node.swift
+++ b/Sources/CommonMark/Nodes/Node.swift
@@ -81,7 +81,7 @@ open class Node {
         case CMARK_NODE_CODE:
             return Code(cmark_node)
         case CMARK_NODE_HTML_INLINE:
-            return HTML(cmark_node)
+            return RawHTML(cmark_node)
         case CMARK_NODE_EMPH:
             return Emphasis(cmark_node)
         case CMARK_NODE_STRONG:

--- a/Sources/CommonMark/Supporting Types/Inline.swift
+++ b/Sources/CommonMark/Supporting Types/Inline.swift
@@ -9,6 +9,6 @@ extension Emphasis: Inline {}
 extension Link: Inline {}
 extension Image: Inline {}
 extension Code: Inline {}
-extension HTML: Inline {}
+extension RawHTML: Inline {}
 extension SoftLineBreak: Inline {}
 extension HardLineBreak: Inline {}

--- a/Sources/CommonMark/Supporting Types/Literal.swift
+++ b/Sources/CommonMark/Supporting Types/Literal.swift
@@ -25,6 +25,6 @@ extension Literal {
 
 extension Code: Literal {}
 extension CodeBlock: Literal {}
-extension HTML: Literal {}
+extension RawHTML: Literal {}
 extension HTMLBlock: Literal {}
 extension Text: Literal {}

--- a/Sources/CommonMarkBuilder/Convertible Protocols/InlineConvertible.swift
+++ b/Sources/CommonMarkBuilder/Convertible Protocols/InlineConvertible.swift
@@ -12,7 +12,7 @@ extension Emphasis: InlineConvertible {}
 extension Link: InlineConvertible {}
 extension Image: InlineConvertible {}
 extension Code: InlineConvertible {}
-extension HTML: InlineConvertible {}
+extension RawHTML: InlineConvertible {}
 extension SoftLineBreak: InlineConvertible {}
 extension HardLineBreak: InlineConvertible {}
 

--- a/Sources/CommonMarkBuilder/Convertible Protocols/ListItemConvertible.swift
+++ b/Sources/CommonMarkBuilder/Convertible Protocols/ListItemConvertible.swift
@@ -20,7 +20,7 @@ extension Emphasis: ListItemConvertible {}
 extension Link: ListItemConvertible {}
 extension Image: ListItemConvertible {}
 extension Code: ListItemConvertible {}
-extension HTML: ListItemConvertible {}
+extension RawHTML: ListItemConvertible {}
 extension SoftLineBreak: ListItemConvertible {}
 extension HardLineBreak: ListItemConvertible {}
 

--- a/Sources/CommonMarkBuilder/Nodes/Inline/HTML+Builder.swift
+++ b/Sources/CommonMarkBuilder/Nodes/Inline/HTML+Builder.swift
@@ -1,6 +1,6 @@
 import CommonMark
 
-extension HTML {
+extension RawHTML {
     public convenience init(_ closure: () -> String) {
         self.init(literal: closure())
     }


### PR DESCRIPTION
To avoid an unnecessary collision with [HypertextLiteral](https://github.com/nshipster/HypertextLiteral)'s `HTML` type and the HTML module in [Markup](https://github.com/SwiftDocOrg/Markup).