### PR TITLE
Conform Node to Codable

### DIFF
--- a/Sources/CommonMark/Nodes/Block/BlockQuote.swift
+++ b/Sources/CommonMark/Nodes/Block/BlockQuote.swift
@@ -12,7 +12,7 @@ import cmark
  > or (b) a single character > not followed by a space.
  */
 public final class BlockQuote: Node {
-    public override class var cmark_node_type: cmark_node_type { return CMARK_NODE_BLOCK_QUOTE }
+    override class var cmark_node_type: cmark_node_type { return CMARK_NODE_BLOCK_QUOTE }
 
     public convenience init(children: [Block & Node] = []) {
         self.init()

--- a/Sources/CommonMark/Nodes/Block/CodeBlock.swift
+++ b/Sources/CommonMark/Nodes/Block/CodeBlock.swift
@@ -25,7 +25,7 @@ import cmark
  > indented no more than three spaces.
  */
 public final class CodeBlock: Node {
-    public override class var cmark_node_type: cmark_node_type { return CMARK_NODE_CODE_BLOCK }
+    override class var cmark_node_type: cmark_node_type { return CMARK_NODE_CODE_BLOCK }
 
     public convenience init(literal: String? = nil) {
         self.init()

--- a/Sources/CommonMark/Nodes/Block/HTMLBlock.swift
+++ b/Sources/CommonMark/Nodes/Block/HTMLBlock.swift
@@ -11,7 +11,7 @@ import cmark
  > (and will not be escaped in HTML output).
  */
 public final class HTMLBlock: Node {
-    public override class var cmark_node_type: cmark_node_type { return CMARK_NODE_HTML_BLOCK }
+    override class var cmark_node_type: cmark_node_type { return CMARK_NODE_HTML_BLOCK }
 
     public convenience init(literal: String? = nil) {
         self.init()

--- a/Sources/CommonMark/Nodes/Block/Heading.swift
+++ b/Sources/CommonMark/Nodes/Block/Heading.swift
@@ -34,7 +34,7 @@ import cmark
  > thematic break, list item, or HTML block.
  */
 public final class Heading: Node {
-    public override class var cmark_node_type: cmark_node_type { return CMARK_NODE_HEADING }
+    override class var cmark_node_type: cmark_node_type { return CMARK_NODE_HEADING }
 
     static let levelRange: ClosedRange<Int> = 1...6
 

--- a/Sources/CommonMark/Nodes/Block/List.swift
+++ b/Sources/CommonMark/Nodes/Block/List.swift
@@ -43,7 +43,7 @@ public final class List: Node {
     }
 
     public final class Item: Node {
-        public override class var cmark_node_type: cmark_node_type { return CMARK_NODE_ITEM }
+        override class var cmark_node_type: cmark_node_type { return CMARK_NODE_ITEM }
 
         public convenience init(children: [Inline & Node] = []) {
             self.init(children: [Paragraph(children: children)])
@@ -58,7 +58,7 @@ public final class List: Node {
         }
     }
 
-    public override class var cmark_node_type: cmark_node_type { return CMARK_NODE_LIST }
+    override class var cmark_node_type: cmark_node_type { return CMARK_NODE_LIST }
 
     public convenience init(delimiter: Delimiter = .none, children: [List.Item] = []) {
         self.init()

--- a/Sources/CommonMark/Nodes/Block/Paragraph.swift
+++ b/Sources/CommonMark/Nodes/Block/Paragraph.swift
@@ -16,7 +16,7 @@ import cmark
  > concatenating the lines and removing initial and final whitespace.
 */
 public final class Paragraph: Node {
-    public override class var cmark_node_type: cmark_node_type { return CMARK_NODE_PARAGRAPH }
+    override class var cmark_node_type: cmark_node_type { return CMARK_NODE_PARAGRAPH }
 
     public convenience init(text string: String, replacingNewLinesWithBreaks: Bool = true) {
         let children: [Inline & Node]

--- a/Sources/CommonMark/Nodes/Block/ThematicBreak.swift
+++ b/Sources/CommonMark/Nodes/Block/ThematicBreak.swift
@@ -13,7 +13,7 @@ import cmark
  > forms a thematic break.
  */
 public final class ThematicBreak: Node {
-    public override class var cmark_node_type: cmark_node_type { return CMARK_NODE_THEMATIC_BREAK }
+    override class var cmark_node_type: cmark_node_type { return CMARK_NODE_THEMATIC_BREAK }
 
     public convenience init() {
         self.init(nonrecursively: ())

--- a/Sources/CommonMark/Nodes/Document.swift
+++ b/Sources/CommonMark/Nodes/Document.swift
@@ -46,7 +46,7 @@ public final class Document: Node {
         case invalid
     }
 
-    public override class var cmark_node_type: cmark_node_type { return CMARK_NODE_DOCUMENT }
+    override class var cmark_node_type: cmark_node_type { return CMARK_NODE_DOCUMENT }
 
     /**
      Creates a document from a CommonMark string.

--- a/Sources/CommonMark/Nodes/Inline/Code.swift
+++ b/Sources/CommonMark/Nodes/Inline/Code.swift
@@ -11,7 +11,7 @@ import cmark
  > and ends with a backtick string of equal length.
 */
 public final class Code: Node {
-    public override class var cmark_node_type: cmark_node_type { return CMARK_NODE_CODE }
+    override class var cmark_node_type: cmark_node_type { return CMARK_NODE_CODE }
 
     public convenience init(literal: String? = nil) {
         self.init()

--- a/Sources/CommonMark/Nodes/Inline/Emphasis.swift
+++ b/Sources/CommonMark/Nodes/Inline/Emphasis.swift
@@ -8,7 +8,7 @@ import cmark
  > ## [6.4 Emphasis and strong emphasis](https://spec.commonmark.org/0.29/#emphasis-and-strong-emphasis)
 */
 public final class Emphasis: Node {
-    public override class var cmark_node_type: cmark_node_type { return CMARK_NODE_EMPH }
+    override class var cmark_node_type: cmark_node_type { return CMARK_NODE_EMPH }
 
     public convenience init(text string: String) {
         self.init(children: [Text(literal: string)])

--- a/Sources/CommonMark/Nodes/Inline/HardLineBreak.swift
+++ b/Sources/CommonMark/Nodes/Inline/HardLineBreak.swift
@@ -14,7 +14,7 @@ import cmark
  > (rendered in HTML as a `<br />` tag):
  */
 public final class HardLineBreak: Node {
-    public override class var cmark_node_type: cmark_node_type { return CMARK_NODE_LINEBREAK }
+    override class var cmark_node_type: cmark_node_type { return CMARK_NODE_LINEBREAK }
 
     public convenience init() {
         self.init(nonrecursively: ())

--- a/Sources/CommonMark/Nodes/Inline/Image.swift
+++ b/Sources/CommonMark/Nodes/Inline/Image.swift
@@ -8,7 +8,7 @@ import cmark
  > ## [6.6 Images](https://spec.commonmark.org/0.29/#images)
 */
 public final class Image: Node {
-    public override class var cmark_node_type: cmark_node_type { return CMARK_NODE_IMAGE }
+    override class var cmark_node_type: cmark_node_type { return CMARK_NODE_IMAGE }
 
     public convenience init(urlString: String, title: String? = nil) {
         self.init()

--- a/Sources/CommonMark/Nodes/Inline/Link.swift
+++ b/Sources/CommonMark/Nodes/Inline/Link.swift
@@ -16,7 +16,7 @@ import cmark
  > ## [6.7 Autolinks](https://spec.commonmark.org/0.29/#autolinks)
  */
 public final class Link: Node {
-    public override class var cmark_node_type: cmark_node_type { return CMARK_NODE_LINK }
+    override class var cmark_node_type: cmark_node_type { return CMARK_NODE_LINK }
     
     public convenience init(urlString: String, title: String? = nil, text string: String) {
         self.init(urlString: urlString, title: title, children: [Text(literal: string)])

--- a/Sources/CommonMark/Nodes/Inline/RawHTML.swift
+++ b/Sources/CommonMark/Nodes/Inline/RawHTML.swift
@@ -14,7 +14,7 @@ import cmark
  > so custom tags (and even, say, DocBook tags) may be used.
 */
 public final class RawHTML: Node {
-    public override class var cmark_node_type: cmark_node_type { return CMARK_NODE_HTML_INLINE }
+    override class var cmark_node_type: cmark_node_type { return CMARK_NODE_HTML_INLINE }
 
     public convenience init(literal: String?) {
         self.init()

--- a/Sources/CommonMark/Nodes/Inline/SoftLineBreak.swift
+++ b/Sources/CommonMark/Nodes/Inline/SoftLineBreak.swift
@@ -15,7 +15,7 @@ import cmark
  > The result will be the same in browsers.)
 */
 public final class SoftLineBreak: Node {
-    public override class var cmark_node_type: cmark_node_type { return CMARK_NODE_SOFTBREAK }
+    override class var cmark_node_type: cmark_node_type { return CMARK_NODE_SOFTBREAK }
 
     public convenience init() {
         self.init(nonrecursively: ())

--- a/Sources/CommonMark/Nodes/Inline/Strong.swift
+++ b/Sources/CommonMark/Nodes/Inline/Strong.swift
@@ -8,7 +8,7 @@ import cmark
  > ## [6.4 Emphasis and strong emphasis](https://spec.commonmark.org/0.29/#emphasis-and-strong-emphasis)
 */
 public final class Strong: Node {
-    public override class var cmark_node_type: cmark_node_type { return CMARK_NODE_STRONG }
+    override class var cmark_node_type: cmark_node_type { return CMARK_NODE_STRONG }
 
     public convenience init(text string: String) {
         self.init(children: [Text(literal: string)])

--- a/Sources/CommonMark/Nodes/Inline/Text.swift
+++ b/Sources/CommonMark/Nodes/Inline/Text.swift
@@ -11,7 +11,7 @@ import cmark
  > will be parsed as plain textual content.
 */
 public final class Text: Node {
-    public override class var cmark_node_type: cmark_node_type { return CMARK_NODE_TEXT }
+    override class var cmark_node_type: cmark_node_type { return CMARK_NODE_TEXT }
 
     public convenience init(literal: String? = nil) {
         self.init()

--- a/Tests/CommonMarkTests/DocumentCodingTests.swift
+++ b/Tests/CommonMarkTests/DocumentCodingTests.swift
@@ -1,0 +1,54 @@
+import XCTest
+import CommonMark
+
+final class DocumentCodingTests: XCTestCase {
+    func testDocumentCodingRoundTrip() throws {
+        let document = try Document(Fixtures.uhdr)
+
+        let encoder = JSONEncoder()
+        let encoded = try encoder.encode(document)
+
+        let decoder = JSONDecoder()
+        let decoded = try decoder.decode(Document.self, from: encoded)
+
+        let expected = document.render(format: .html)
+        let actual = decoded.render(format: .html)
+
+        XCTAssertEqual(expected, actual)
+    }
+
+    func testBlockElementCodingRoundTrip() throws {
+        let document = try Document(Fixtures.uhdr)
+
+        let heading = document.children.first! as! Heading
+
+        let encoder = JSONEncoder()
+        let encoded = try encoder.encode(heading)
+
+        let decoder = JSONDecoder()
+        let decoded = try decoder.decode(Heading.self, from: encoded)
+
+        let expected = try Document(heading.description).render(format: .html)
+        let actual = try Document(decoded.description).render(format: .html)
+
+        XCTAssertEqual(expected, actual)
+    }
+
+    func testInlineElementCodingRoundTrip() throws {
+        let document = try Document(Fixtures.uhdr)
+
+        let heading = document.children.first! as! Heading
+        let link = heading.children.first! as! Link
+
+        let encoder = JSONEncoder()
+        let encoded = try encoder.encode(link)
+
+        let decoder = JSONDecoder()
+        let decoded = try decoder.decode(Link.self, from: encoded)
+
+        let expected = try Document(link.description).render(format: .html)
+        let actual = try Document(decoded.description).render(format: .html)
+
+        XCTAssertEqual(expected, actual)
+    }
+}

--- a/Tests/CommonMarkTests/DocumentCodingTests.swift
+++ b/Tests/CommonMarkTests/DocumentCodingTests.swift
@@ -5,14 +5,12 @@ final class DocumentCodingTests: XCTestCase {
     func testDocumentCodingRoundTrip() throws {
         let document = try Document(Fixtures.uhdr)
 
-        let encoder = JSONEncoder()
-        let encoded = try encoder.encode(document)
-
-        let decoder = JSONDecoder()
-        let decoded = try decoder.decode(Document.self, from: encoded)
+        // Workaround for "Top-level Document encoded as string JSON fragment."
+        let encoded = try JSONEncoder().encode([document])
+        let decoded = try JSONDecoder().decode([Document].self, from: encoded)
 
         let expected = document.render(format: .html)
-        let actual = decoded.render(format: .html)
+        let actual = decoded[0].render(format: .html)
 
         XCTAssertEqual(expected, actual)
     }
@@ -22,14 +20,12 @@ final class DocumentCodingTests: XCTestCase {
 
         let heading = document.children.first! as! Heading
 
-        let encoder = JSONEncoder()
-        let encoded = try encoder.encode(heading)
-
-        let decoder = JSONDecoder()
-        let decoded = try decoder.decode(Heading.self, from: encoded)
+        // Workaround for "Top-level Heading encoded as string JSON fragment."
+        let encoded = try JSONEncoder().encode([heading])
+        let decoded = try JSONDecoder().decode([Heading].self, from: encoded)
 
         let expected = try Document(heading.description).render(format: .html)
-        let actual = try Document(decoded.description).render(format: .html)
+        let actual = try Document(decoded[0].description).render(format: .html)
 
         XCTAssertEqual(expected, actual)
     }
@@ -40,14 +36,12 @@ final class DocumentCodingTests: XCTestCase {
         let heading = document.children.first! as! Heading
         let link = heading.children.first! as! Link
 
-        let encoder = JSONEncoder()
-        let encoded = try encoder.encode(link)
-
-        let decoder = JSONDecoder()
-        let decoded = try decoder.decode(Link.self, from: encoded)
+        // Workaround for "Top-level Link encoded as string JSON fragment."
+        let encoded = try JSONEncoder().encode([link])
+        let decoded = try JSONDecoder().decode([Link].self, from: encoded)
 
         let expected = try Document(link.description).render(format: .html)
-        let actual = try Document(decoded.description).render(format: .html)
+        let actual = try Document(decoded[0].description).render(format: .html)
 
         XCTAssertEqual(expected, actual)
     }


### PR DESCRIPTION
This also changes the access level of Node from `open` to `public`, and makes APIs referencing `cmark_node` values `internal`.