### PR TITLE
Fix parent/child relationship between a document and its constituent nodes

### DIFF
--- a/Sources/CommonMark/Nodes/Node.swift
+++ b/Sources/CommonMark/Nodes/Node.swift
@@ -46,6 +46,8 @@ public class Node: Codable {
         guard let cmark_node = cmark_node else { return nil }
 
         switch cmark_node_get_type(cmark_node) {
+        case CMARK_NODE_DOCUMENT:
+            return Document(cmark_node)
         case CMARK_NODE_BLOCK_QUOTE:
             return BlockQuote(cmark_node)
         case CMARK_NODE_LIST:

--- a/Tests/CommonMarkTests/DocumentParsingTests.swift
+++ b/Tests/CommonMarkTests/DocumentParsingTests.swift
@@ -10,17 +10,21 @@ final class DocumentParsingTests: XCTestCase {
         let heading = document.children[0] as! Heading
         XCTAssertEqual(heading.level, 1)
         XCTAssertEqual(heading.children.count, 1)
+        XCTAssertEqual(heading.parent, document)
 
         let link = heading.children[0] as! Link
         XCTAssertEqual(link.urlString, "https://www.un.org/en/universal-declaration-human-rights/")
         XCTAssertEqual(link.title, "View full version")
+        XCTAssertEqual(link.parent, heading)
 
         let subheading = document.children[1] as! Heading
         XCTAssertEqual(subheading.level, 2)
         XCTAssertEqual(subheading.children.count, 1)
+        XCTAssertEqual(subheading.parent, document)
 
         let subheadingText = subheading.children[0] as! Text
         XCTAssertEqual(subheadingText.literal, "Article 1.")
+        XCTAssertEqual(subheadingText.parent, subheading)
 
         let paragraph = document.children[2] as! Paragraph
         XCTAssert(paragraph.description.starts(with: "All human beings"))
@@ -28,6 +32,7 @@ final class DocumentParsingTests: XCTestCase {
         XCTAssertEqual(paragraph.range.lowerBound.column, 1)
         XCTAssertEqual(paragraph.range.upperBound.line, 7)
         XCTAssertEqual(paragraph.range.upperBound.column, 62)
+        XCTAssertEqual(paragraph.parent, document)
     }
 
     // https://github.com/SwiftDocOrg/CommonMark/issues/1


### PR DESCRIPTION
Adds a missing `case` for `CMARK_NODE_DOCUMENT` in the `Node.create(for:)` class constructor method.

Fixes #7.