### PR TITLE
Fix document manipulation

### DIFF
--- a/Sources/CommonMark/Supporting Types/Children.swift
+++ b/Sources/CommonMark/Supporting Types/Children.swift
@@ -292,7 +292,7 @@ extension List {
     */
     @discardableResult
     public func insert(child: Item, before sibling: Item) -> Bool {
-        return add(child) { cmark_node_insert_before(child.cmark_node, sibling.cmark_node) }
+        return add(child) { cmark_node_insert_before(sibling.cmark_node, child.cmark_node) }
     }
 
     /**
@@ -305,7 +305,7 @@ extension List {
     */
     @discardableResult
     public func insert(child: Item, after sibling: Item) -> Bool {
-        return add(child) { cmark_node_insert_after(child.cmark_node, sibling.cmark_node) }
+        return add(child) { cmark_node_insert_after(sibling.cmark_node, child.cmark_node) }
     }
 
     /**

--- a/Sources/CommonMark/Supporting Types/Children.swift
+++ b/Sources/CommonMark/Supporting Types/Children.swift
@@ -206,7 +206,7 @@ extension ContainerOfInlineElements {
     */
     @discardableResult
     public func insert(child: Inline & Node, before sibling: Inline & Node) -> Bool {
-        return add(child) { cmark_node_insert_before(child.cmark_node, sibling.cmark_node) }
+        return add(child) { cmark_node_insert_before(sibling.cmark_node, child.cmark_node) }
     }
 
     /**
@@ -219,7 +219,7 @@ extension ContainerOfInlineElements {
     */
     @discardableResult
     public func insert(child: Inline & Node, after sibling: Inline & Node) -> Bool {
-        return add(child) { cmark_node_insert_after(child.cmark_node, sibling.cmark_node) }
+        return add(child) { cmark_node_insert_after(sibling.cmark_node, child.cmark_node) }
     }
 
     /**

--- a/Sources/CommonMark/Supporting Types/Children.swift
+++ b/Sources/CommonMark/Supporting Types/Children.swift
@@ -378,7 +378,7 @@ extension List.Item {
     */
     @discardableResult
     public func insert(child: Node, before sibling: Node) -> Bool {
-        return add(child) { cmark_node_insert_before(child.cmark_node, sibling.cmark_node) }
+        return add(child) { cmark_node_insert_before(sibling.cmark_node, child.cmark_node) }
     }
 
     /**
@@ -391,7 +391,7 @@ extension List.Item {
     */
     @discardableResult
     public func insert(child: Node, after sibling: Node) -> Bool {
-        return add(child) { cmark_node_insert_after(child.cmark_node, sibling.cmark_node) }
+        return add(child) { cmark_node_insert_after(sibling.cmark_node, child.cmark_node) }
     }
 
     /**

--- a/Sources/CommonMark/Supporting Types/Children.swift
+++ b/Sources/CommonMark/Supporting Types/Children.swift
@@ -109,7 +109,7 @@ extension ContainerOfBlocks {
     */
     @discardableResult
     public func insert(child: Block & Node, before sibling: Block & Node) -> Bool {
-        return add(child) { cmark_node_insert_before(child.cmark_node, sibling.cmark_node) }
+        return add(child) { cmark_node_insert_before(sibling.cmark_node, child.cmark_node) }
     }
 
     /**
@@ -122,7 +122,7 @@ extension ContainerOfBlocks {
     */
     @discardableResult
     public func insert(child: Block & Node, after sibling: Block & Node) -> Bool {
-        return add(child) { cmark_node_insert_after(child.cmark_node, sibling.cmark_node) }
+        return add(child) { cmark_node_insert_after(sibling.cmark_node, child.cmark_node) }
     }
 
     /**

--- a/Tests/CommonMarkTests/ContainerManipulationTests.swift
+++ b/Tests/CommonMarkTests/ContainerManipulationTests.swift
@@ -31,4 +31,21 @@ final class ContainerManipulationTests: XCTestCase {
         XCTAssertEqual(document.children.count, 5)
         XCTAssertEqual(newSubheading, document.children[3])
     }
+    
+    func testContainerOfInlineElementsManipulation() throws {
+        let document = try Document(Fixtures.uhdr)
+
+        let paragraph = document.children[2] as! Paragraph
+        XCTAssertEqual(paragraph.children.count, 5)
+
+        let text = Text(literal: "Article 1:")
+        let wasTextInserted = paragraph.insert(child: text, before: paragraph.children[0])
+        XCTAssertTrue(wasTextInserted)
+        XCTAssertEqual(paragraph.children[0], text)
+
+        let lineBrake = SoftLineBreak()
+        let wasLineBreakInserted = paragraph.insert(child: lineBrake, after: text)
+        XCTAssertTrue(wasLineBreakInserted)
+        XCTAssertEqual(paragraph.children[1], lineBrake)
+    }
 }

--- a/Tests/CommonMarkTests/ContainerManipulationTests.swift
+++ b/Tests/CommonMarkTests/ContainerManipulationTests.swift
@@ -70,4 +70,19 @@ final class ContainerManipulationTests: XCTestCase {
         XCTAssertTrue(wasFithInserted)
         XCTAssertEqual(list.children[4], fifth)
     }
+
+    func testListItemManipulation() throws {
+
+        let listItem = List.Item(children: [Paragraph(text: "First")])
+
+        let secondChild = Paragraph(text: "Second")
+        let wasSecondChildInserted = listItem.insert(child: secondChild, after: listItem.children[0])
+        XCTAssertTrue(wasSecondChildInserted)
+        XCTAssertEqual(listItem.children[1], secondChild)
+
+        let thirdChild = Paragraph(text: "Third")
+        let wasThirdChildInserted = listItem.insert(child: thirdChild, before: listItem.children[0])
+        XCTAssertTrue(wasThirdChildInserted)
+        XCTAssertEqual(listItem.children[0], thirdChild)
+    }
 }

--- a/Tests/CommonMarkTests/ContainerManipulationTests.swift
+++ b/Tests/CommonMarkTests/ContainerManipulationTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+import CommonMark
+
+final class ContainerManipulationTests: XCTestCase {
+    func testContainerOfBlocksManipulation() throws {
+        let document = try Document(Fixtures.uhdr)
+
+        XCTAssertEqual(document.children.count, 3)
+        let heading = document.children[0] as! Heading
+        XCTAssertEqual(heading.level, 1)
+        let subheading = document.children[1] as! Heading
+        XCTAssertEqual(subheading.level, 2)
+        let paragraph = document.children[2] as! Paragraph
+        XCTAssert(paragraph.description.starts(with: "All human beings"))
+
+        let newParagraph = Paragraph(text:
+           #"""
+           Everyone is entitled to all the rights and freedoms set forth in this Declaration, 
+           without distinction of any kind, such as race, colour, sex, language, religion, 
+           political or other opinion, national or social origin, property, birth or other status.
+           """#)
+        let wasNewParagraphInserted = document.insert(child: newParagraph, after: paragraph)
+
+        XCTAssertTrue(wasNewParagraphInserted)
+        XCTAssertEqual(document.children.count, 4)
+        XCTAssertEqual(newParagraph, document.children[3])
+
+        let newSubheading = Heading(level: 2, text: "Article 2.")
+        let wasSubheadingInserted = document.insert(child: newSubheading, before: newParagraph)
+        XCTAssertTrue(wasSubheadingInserted)
+        XCTAssertEqual(document.children.count, 5)
+        XCTAssertEqual(newSubheading, document.children[3])
+    }
+}

--- a/Tests/CommonMarkTests/ContainerManipulationTests.swift
+++ b/Tests/CommonMarkTests/ContainerManipulationTests.swift
@@ -48,4 +48,26 @@ final class ContainerManipulationTests: XCTestCase {
         XCTAssertTrue(wasLineBreakInserted)
         XCTAssertEqual(paragraph.children[1], lineBrake)
     }
+    
+    func testListManipulation() throws {
+        let document = try Document(
+            #"""
+            * First
+            * Second
+            * Forth
+            """#)
+        
+        let list = document.children[0] as! List
+        XCTAssertEqual(list.children.count, 3)
+
+        let third = List.Item(children: [Text(literal: "Third")])
+        let wasThirdInserted = list.insert(child: third, before: list.children[2])
+        XCTAssertTrue(wasThirdInserted)
+        XCTAssertEqual(list.children[2], third)
+
+        let fifth = List.Item(children: [Text(literal: "Fifth")])
+        let wasFithInserted = list.insert(child: fifth, after: list.children[3])
+        XCTAssertTrue(wasFithInserted)
+        XCTAssertEqual(list.children[4], fifth)
+    }
 }

--- a/Tests/CommonMarkTests/ContainerManipulationTests.swift
+++ b/Tests/CommonMarkTests/ContainerManipulationTests.swift
@@ -43,10 +43,10 @@ final class ContainerManipulationTests: XCTestCase {
         XCTAssertTrue(wasTextInserted)
         XCTAssertEqual(paragraph.children[0], text)
 
-        let lineBrake = SoftLineBreak()
-        let wasLineBreakInserted = paragraph.insert(child: lineBrake, after: text)
+        let lineBreak = SoftLineBreak()
+        let wasLineBreakInserted = paragraph.insert(child: lineBreak, after: text)
         XCTAssertTrue(wasLineBreakInserted)
-        XCTAssertEqual(paragraph.children[1], lineBrake)
+        XCTAssertEqual(paragraph.children[1], lineBreak)
     }
     
     func testListManipulation() throws {
@@ -54,7 +54,7 @@ final class ContainerManipulationTests: XCTestCase {
             #"""
             * First
             * Second
-            * Forth
+            * Fourth
             """#)
         
         let list = document.children[0] as! List
@@ -66,15 +66,13 @@ final class ContainerManipulationTests: XCTestCase {
         XCTAssertEqual(list.children[2], third)
 
         let fifth = List.Item(children: [Text(literal: "Fifth")])
-        let wasFithInserted = list.insert(child: fifth, after: list.children[3])
-        XCTAssertTrue(wasFithInserted)
+        let wasFifthInserted = list.insert(child: fifth, after: list.children[3])
+        XCTAssertTrue(wasFifthInserted)
         XCTAssertEqual(list.children[4], fifth)
     }
 
     func testListItemManipulation() throws {
-
         let listItem = List.Item(children: [Paragraph(text: "First")])
-
         let secondChild = Paragraph(text: "Second")
         let wasSecondChildInserted = listItem.insert(child: secondChild, after: listItem.children[0])
         XCTAssertTrue(wasSecondChildInserted)


### PR DESCRIPTION
Fixes #9 

I'm not entirely happy with the mismatch of `sibling` now. Our sibling is exactly the other node than cmark's sibling. But I did not want to break the existing public API.