### PR TITLE
Fix memory leaks

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed document parsing options.
   #21 by @regexident.
+- Fixed memory leaks.
+  #22 by @regexident.
 
 ## [0.4.0] - 2020-05-01
 

--- a/Sources/CommonMark/Nodes/Document.swift
+++ b/Sources/CommonMark/Nodes/Document.swift
@@ -62,6 +62,7 @@ public final class Document: Node {
         }
 
         self.init(cmark_node)
+        self.managed = managed
     }
 
     public convenience init(children: [Block & Node] = []) {

--- a/Sources/CommonMark/Nodes/Document.swift
+++ b/Sources/CommonMark/Nodes/Document.swift
@@ -62,7 +62,7 @@ public final class Document: Node {
         }
 
         self.init(cmark_node)
-        self.managed = managed
+        self.managed = true
     }
 
     public convenience init(children: [Block & Node] = []) {

--- a/Sources/CommonMark/Nodes/Document.swift
+++ b/Sources/CommonMark/Nodes/Document.swift
@@ -57,7 +57,8 @@ public final class Document: Node {
           if a document couldn't be constructed with the provided source.
      */
     public convenience init(_ commonmark: String, options: ParsingOptions = []) throws {
-        guard let cmark_node = cmark_parse_document(commonmark, commonmark.utf8.count, options.rawValue) else {
+        guard let cmark_node = cmark_parse_document(commonmark, commonmark.utf8.count, options.rawValue)
+        else {
             throw Error.invalid
         }
 

--- a/Sources/CommonMark/Nodes/Node.swift
+++ b/Sources/CommonMark/Nodes/Node.swift
@@ -290,6 +290,8 @@ public class Node: Codable {
         else {
             throw DecodingError.dataCorruptedError(in: container, debugDescription: "expected single block node")
         }
+
+        assert(block.managed)
         return block
     }
 
@@ -315,6 +317,8 @@ public class Node: Codable {
         else {
             throw DecodingError.dataCorruptedError(in: container, debugDescription: "expected single inline node")
         }
+
+        assert(inline.managed)
         return inline
     }
 }

--- a/Sources/CommonMark/Nodes/Node.swift
+++ b/Sources/CommonMark/Nodes/Node.swift
@@ -94,9 +94,8 @@ public class Node: Codable {
         }
     }
 
-    internal func unlink(managed: Bool = true) {
+    func unlink() {
         cmark_node_unlink(self.cmark_node)
-        self.managed = managed
     }
 
     /// The line and column range of the element in the document.
@@ -271,9 +270,10 @@ public class Node: Codable {
             throw DecodingError.dataCorruptedError(in: container, debugDescription: "unsupported node type")
         }
 
-        node.unlink(managed: false)
-        self.init(node.cmark_node)
+        node.unlink()
+        node.managed = false
 
+        self.init(node.cmark_node)
         self.managed = true
     }
 

--- a/Sources/CommonMark/Nodes/Node.swift
+++ b/Sources/CommonMark/Nodes/Node.swift
@@ -346,12 +346,6 @@ extension Node: Hashable {
 
 extension Node: CustomStringConvertible {
     public var description: String {
-        let cString = cmark_render_commonmark(cmark_node, 0, 0)!
-
-        defer {
-            free(cString)
-        }
-
-        return String(cString: cString)
+        self.render(format: .commonmark)
     }
 }

--- a/Sources/CommonMark/Nodes/Node.swift
+++ b/Sources/CommonMark/Nodes/Node.swift
@@ -345,6 +345,12 @@ extension Node: Hashable {
 
 extension Node: CustomStringConvertible {
     public var description: String {
-        return String(cString: cmark_render_commonmark(cmark_node, 0, 0))
+        let cString = cmark_render_commonmark(cmark_node, 0, 0)!
+
+        defer {
+            free(cString)
+        }
+
+        return String(cString: cString)
     }
 }

--- a/Sources/CommonMark/Nodes/Node.swift
+++ b/Sources/CommonMark/Nodes/Node.swift
@@ -198,18 +198,26 @@ public class Node: Codable {
     public func render(format: RenderingFormat, options: RenderingOptions = [], width: Int = 0) -> String {
         precondition(width >= 0)
 
+        let cString: UnsafeMutablePointer<CChar>
+
         switch format {
         case .commonmark:
-            return String(cString: cmark_render_commonmark(cmark_node, options.rawValue, Int32(clamping: width)))
+            cString = cmark_render_commonmark(cmark_node, options.rawValue, Int32(clamping: width))
         case .html:
-            return String(cString: cmark_render_html(cmark_node, options.rawValue))
+            cString = cmark_render_html(cmark_node, options.rawValue)
         case .xml:
-            return String(cString: cmark_render_xml(cmark_node, options.rawValue))
+            cString = cmark_render_xml(cmark_node, options.rawValue)
         case .latex:
-            return String(cString: cmark_render_latex(cmark_node, options.rawValue, Int32(clamping: width)))
+            cString = cmark_render_latex(cmark_node, options.rawValue, Int32(clamping: width))
         case .manpage:
-            return String(cString: cmark_render_man(cmark_node, options.rawValue, Int32(clamping: width)))
+            cString = cmark_render_man(cmark_node, options.rawValue, Int32(clamping: width))
         }
+
+        defer {
+            free(cString)
+        }
+
+        return String(cString: cString)
     }
 
     // MARK: - Codable

--- a/Sources/CommonMark/Nodes/Node.swift
+++ b/Sources/CommonMark/Nodes/Node.swift
@@ -279,6 +279,10 @@ public class Node: Codable {
     }
 
     private static func extractRootBlock(from document: Document, in container: SingleValueDecodingContainer) throws -> Self {
+        // We need to unlink the children from the given node
+        // so that they can outlive it, or we end up with dangling pointers.
+        // The easiest way to accomplish this is to use `drain()`,
+        // which removes the children from their parent before returning them:
         let documentChildren = document.drain()
         guard let block = documentChildren.first as? Self,
             documentChildren.count == 1
@@ -289,6 +293,10 @@ public class Node: Codable {
     }
 
     private static func extractRootInline(from document: Document, in container: SingleValueDecodingContainer) throws -> Self {
+        // We need to unlink the children from the given node
+        // so that they can outlive it, or we end up with dangling pointers.
+        // The easiest way to accomplish this is to use `drain()`,
+        // which removes the children from their parent before returning them:
         let documentChildren = document.drain()
         guard let paragraph = documentChildren.first as? Paragraph,
             documentChildren.count == 1
@@ -296,6 +304,10 @@ public class Node: Codable {
             throw DecodingError.dataCorruptedError(in: container, debugDescription: "expected single paragraph node")
         }
 
+        // We need to unlink the children from the given node
+        // so that they can outlive it, or we end up with dangling pointers.
+        // The easiest way to accomplish this is to use `drain()`,
+        // which removes the children from their parent before returning them:
         let paragraphChildren = paragraph.drain()
         guard let inline = paragraphChildren.first as? Self,
             paragraphChildren.count == 1

--- a/Sources/CommonMark/Nodes/Node.swift
+++ b/Sources/CommonMark/Nodes/Node.swift
@@ -94,6 +94,11 @@ public class Node: Codable {
         }
     }
 
+    internal func unlink(managed: Bool = true) {
+        cmark_node_unlink(self.cmark_node)
+        self.managed = managed
+    }
+
     /// The line and column range of the element in the document.
     public var range: ClosedRange<Document.Position> {
         let start = Document.Position(line: numericCast(cmark_node_get_start_line(cmark_node)), column: numericCast(cmark_node_get_start_column(cmark_node)))

--- a/Sources/CommonMark/Nodes/Node.swift
+++ b/Sources/CommonMark/Nodes/Node.swift
@@ -330,8 +330,14 @@ extension Node: Equatable {
 
 extension Node: Hashable {
     public func hash(into hasher: inout Hasher) {
+        let cString = cmark_render_commonmark(cmark_node, 0, 0)!
+
+        defer {
+            free(cString)
+        }
+
         hasher.combine(cmark_node_get_type(cmark_node).rawValue)
-        hasher.combine(cmark_render_commonmark(cmark_node, 0, 0))
+        hasher.combine(cString)
     }
 }
 

--- a/Sources/CommonMark/Nodes/Node.swift
+++ b/Sources/CommonMark/Nodes/Node.swift
@@ -225,8 +225,7 @@ public class Node: Codable {
         switch Self.cmark_node_type {
         case CMARK_NODE_DOCUMENT:
             node = document
-        case CMARK_NODE_DOCUMENT,
-             CMARK_NODE_BLOCK_QUOTE,
+        case CMARK_NODE_BLOCK_QUOTE,
              CMARK_NODE_LIST,
              CMARK_NODE_ITEM,
              CMARK_NODE_CODE_BLOCK,

--- a/Sources/CommonMark/Nodes/Node.swift
+++ b/Sources/CommonMark/Nodes/Node.swift
@@ -257,10 +257,19 @@ public class Node: Codable {
             throw DecodingError.dataCorruptedError(in: container, debugDescription: "unsupported node type")
         }
 
-        node.unlink()
+        // If the extracted node is not managed, then we most likely
+        // introduced a memory bug in our extraction logic:
+        assert(
+            node.managed,
+            "Expected extracted node to be managed"
+        )
+
+        // Un-assign memory management duties from old owning node:
         node.managed = false
 
         self.init(node.cmark_node)
+
+        // Re-assign memory management duties to new owning node:
         self.managed = true
     }
 

--- a/Sources/CommonMark/Nodes/Node.swift
+++ b/Sources/CommonMark/Nodes/Node.swift
@@ -96,6 +96,7 @@ public class Node: Codable {
 
     func unlink() {
         cmark_node_unlink(self.cmark_node)
+        self.managed = true
     }
 
     /// The line and column range of the element in the document.

--- a/Sources/CommonMark/Nodes/Node.swift
+++ b/Sources/CommonMark/Nodes/Node.swift
@@ -280,11 +280,8 @@ public class Node: Codable {
     }
 
     private static func extractRootBlock(from document: Document, in container: SingleValueDecodingContainer) throws -> Self {
-        // We need to unlink the children from the given node
-        // so that they can outlive it, or we end up with dangling pointers.
-        // The easiest way to accomplish this is to use `drain()`,
-        // which removes the children from their parent before returning them:
-        let documentChildren = document.drain()
+        // Unlink the children from the document node to prevent dangling pointers to the parent.
+        let documentChildren = document.removeChildren()
         guard let block = documentChildren.first as? Self,
             documentChildren.count == 1
         else {
@@ -296,22 +293,16 @@ public class Node: Codable {
     }
 
     private static func extractRootInline(from document: Document, in container: SingleValueDecodingContainer) throws -> Self {
-        // We need to unlink the children from the given node
-        // so that they can outlive it, or we end up with dangling pointers.
-        // The easiest way to accomplish this is to use `drain()`,
-        // which removes the children from their parent before returning them:
-        let documentChildren = document.drain()
+        // Unlink the children from the document node to prevent dangling pointers to the parent.
+        let documentChildren = document.removeChildren()
         guard let paragraph = documentChildren.first as? Paragraph,
             documentChildren.count == 1
         else {
             throw DecodingError.dataCorruptedError(in: container, debugDescription: "expected single paragraph node")
         }
 
-        // We need to unlink the children from the given node
-        // so that they can outlive it, or we end up with dangling pointers.
-        // The easiest way to accomplish this is to use `drain()`,
-        // which removes the children from their parent before returning them:
-        let paragraphChildren = paragraph.drain()
+        // Unlink the children from the root node to prevent dangling pointers to the parent.
+        let paragraphChildren = paragraph.removeChildren()
         guard let inline = paragraphChildren.first as? Self,
             paragraphChildren.count == 1
         else {

--- a/Sources/CommonMark/Supporting Types/Children.swift
+++ b/Sources/CommonMark/Supporting Types/Children.swift
@@ -82,7 +82,7 @@ extension ContainerOfBlocks {
     }
 
     /**
-     Adds a block to the beginning of the block's children.
+     Adds a block to the beginning of the node's children.
 
      - Parameters:
         - child: The block to add.
@@ -94,7 +94,7 @@ extension ContainerOfBlocks {
     }
 
     /**
-     Adds a block to the end of the block's children.
+     Adds a block to the end of the node's children.
 
      - Parameters:
         - child: The block to add.
@@ -106,7 +106,7 @@ extension ContainerOfBlocks {
     }
 
     /**
-     Inserts a block to the block's children before a specified sibling.
+     Inserts a block to the node's children before a specified sibling.
 
      - Parameters:
         - child: The block to add.
@@ -119,7 +119,7 @@ extension ContainerOfBlocks {
     }
 
     /**
-     Inserts a block to the block's children after a specified sibling.
+     Inserts a block to the node's children after a specified sibling.
 
      - Parameters:
         - child: The block to add.
@@ -132,7 +132,7 @@ extension ContainerOfBlocks {
     }
 
     /**
-     Removes a block from the block's children.
+     Removes a block from the node's children.
 
      - Parameters:
         - child: The block to remove.
@@ -202,7 +202,7 @@ extension ContainerOfInlineElements {
     }
 
     /**
-     Adds an inline element to the beginning of the block's children.
+     Adds an inline element to the beginning of the node's children.
 
      - Parameters:
         - child: The inline element to add.
@@ -214,7 +214,7 @@ extension ContainerOfInlineElements {
     }
 
     /**
-     Adds an inline element to the end of the block's children.
+     Adds an inline element to the end of the node's children.
 
      - Parameters:
         - child: The inline element to add.
@@ -226,7 +226,7 @@ extension ContainerOfInlineElements {
     }
 
     /**
-     Inserts an inline element to the block's children before a specified sibling.
+     Inserts an inline element to the node's children before a specified sibling.
 
      - Parameters:
         - child: The inline element to add.
@@ -239,7 +239,7 @@ extension ContainerOfInlineElements {
     }
 
     /**
-     Inserts an inline element to the block's children after a specified sibling.
+     Inserts an inline element to the node's children after a specified sibling.
 
      - Parameters:
         - child: The inline element to add.
@@ -252,7 +252,7 @@ extension ContainerOfInlineElements {
     }
 
     /**
-     Removes an inline element from the block's children.
+     Removes an inline element from the node's children.
 
      - Parameters:
         - child: The inline element to remove.
@@ -311,10 +311,10 @@ extension List {
     }
 
     /**
-     Adds a block to the beginning of the block's children.
+     Adds an item to the beginning of the list.
 
      - Parameters:
-        - child: The block to add.
+        - child: The item to add.
      - Returns: `true` if successful, otherwise `false`.
      */
     @discardableResult
@@ -323,10 +323,10 @@ extension List {
     }
 
     /**
-     Adds a block to the end of the block's children.
+     Adds an to the end of the list.
 
      - Parameters:
-        - child: The block to add.
+        - child: The item to add.
      - Returns: `true` if successful, otherwise `false`.
     */
     @discardableResult
@@ -335,11 +335,11 @@ extension List {
     }
 
     /**
-     Inserts a block to the block's children before a specified sibling.
+     Inserts an item to the list before a specified sibling.
 
      - Parameters:
-        - child: The block to add.
-        - sibling: The child before which the block is added
+        - child: The item to add.
+        - sibling: The item before which the new item is added
      - Returns: `true` if successful, otherwise `false`.
     */
     @discardableResult
@@ -348,11 +348,11 @@ extension List {
     }
 
     /**
-     Inserts a block to the block's children after a specified sibling.
+     Inserts an item to the list after a specified sibling.
 
      - Parameters:
-        - child: The block to add.
-        - sibling: The child after which the block is added
+        - child: The item to add.
+        - sibling: The item after which the new item is added
      - Returns: `true` if successful, otherwise `false`.
     */
     @discardableResult
@@ -361,10 +361,10 @@ extension List {
     }
 
     /**
-     Removes a block from the block's children.
+     Removes an item from the list.
 
      - Parameters:
-        - child: The block to remove.
+        - child: The item to remove.
      - Returns: `true` if successful, otherwise `false`.
      */
     @discardableResult
@@ -423,7 +423,7 @@ extension List.Item {
      Adds a node to the beginning of the list item's children.
 
      - Parameters:
-        - child: The block to add.
+        - child: The node to add.
      - Returns: `true` if successful, otherwise `false`.
      */
     @discardableResult
@@ -435,7 +435,7 @@ extension List.Item {
      Adds a node to the end of the list item's children.
 
      - Parameters:
-        - child: The block to add.
+        - child: The node to add.
      - Returns: `true` if successful, otherwise `false`.
     */
     @discardableResult
@@ -447,8 +447,8 @@ extension List.Item {
      Inserts a node to the list item's children before a specified sibling.
 
      - Parameters:
-        - child: The block to add.
-        - sibling: The child before which the block is added
+        - child: The node to add.
+        - sibling: The child before which the node is added
      - Returns: `true` if successful, otherwise `false`.
     */
     @discardableResult
@@ -460,8 +460,8 @@ extension List.Item {
      Inserts a node to the list item's children after a specified sibling.
 
      - Parameters:
-        - child: The block to add.
-        - sibling: The child after which the block is added
+        - child: The node to add.
+        - sibling: The child after which the node is added
      - Returns: `true` if successful, otherwise `false`.
     */
     @discardableResult
@@ -473,7 +473,7 @@ extension List.Item {
      Removes a node from the list item's children.
 
      - Parameters:
-        - child: The block to remove.
+        - child: The node to remove.
      - Returns: `true` if successful, otherwise `false`.
      */
     @discardableResult

--- a/Sources/CommonMark/Supporting Types/Children.swift
+++ b/Sources/CommonMark/Supporting Types/Children.swift
@@ -136,6 +136,7 @@ extension ContainerOfBlocks {
     public func remove(child: Block & Node) -> Bool {
         guard child.parent == self else { return false }
         child.unlink()
+
         return true
     }
 }
@@ -232,6 +233,7 @@ extension ContainerOfInlineElements {
     public func remove(child: Inline & Node) -> Bool {
         guard child.parent == self else { return false }
         child.unlink()
+
         return true
     }
 }
@@ -315,9 +317,10 @@ extension List {
      */
     @discardableResult
     public func remove(child: Item) -> Bool {
-         guard child.parent == self else { return false }
-         child.unlink()
-         return true
+        guard child.parent == self else { return false }
+        child.unlink()
+
+        return true
     }
 }
 
@@ -402,6 +405,7 @@ extension List.Item {
     public func remove(child: Node) -> Bool {
         guard child.parent == self else { return false }
         child.unlink()
+
         return true
     }
 }

--- a/Sources/CommonMark/Supporting Types/Children.swift
+++ b/Sources/CommonMark/Supporting Types/Children.swift
@@ -75,6 +75,18 @@ extension ContainerOfBlocks {
         }
     }
 
+    /// Removes the block's children and returns them.
+    public func drain() -> [Block & Node] {
+        var children: [Block & Node] = []
+
+        for child in self.children {
+            remove(child: child)
+            children.append(child)
+        }
+
+        return children
+    }
+
     /**
      Adds a block to the beginning of the block's children.
 
@@ -172,6 +184,18 @@ extension ContainerOfInlineElements {
         }
     }
 
+    /// Removes the block's children and returns them.
+    public func drain() -> [Inline & Node] {
+        var children: [Inline & Node] = []
+
+        for child in self.children {
+            remove(child: child)
+            children.append(child)
+        }
+
+        return children
+    }
+
     /**
      Adds an inline element to the beginning of the block's children.
 
@@ -258,6 +282,18 @@ extension List {
         }
     }
 
+    /// Removes the block's children and returns them.
+    public func drain() -> [Item] {
+        var children: [Item] = []
+
+        for child in self.children {
+            remove(child: child)
+            children.append(child)
+        }
+
+        return children
+    }
+
     /**
      Adds a block to the beginning of the block's children.
 
@@ -342,6 +378,18 @@ extension List.Item {
                 append(child: child)
             }
         }
+    }
+
+    /// Removes the block's children and returns them.
+    public func drain() -> [Node] {
+        var children: [Node] = []
+
+        for child in self.children {
+            remove(child: child)
+            children.append(child)
+        }
+
+        return children
     }
 
     /**

--- a/Sources/CommonMark/Supporting Types/Children.swift
+++ b/Sources/CommonMark/Supporting Types/Children.swift
@@ -80,7 +80,7 @@ extension ContainerOfBlocks {
         var children: [Block & Node] = []
 
         for child in self.children {
-            remove(child: child)
+            guard remove(child: child) else { continue }
             children.append(child)
         }
 
@@ -189,7 +189,7 @@ extension ContainerOfInlineElements {
         var children: [Inline & Node] = []
 
         for child in self.children {
-            remove(child: child)
+            guard remove(child: child) else { continue }
             children.append(child)
         }
 
@@ -287,7 +287,7 @@ extension List {
         var children: [Item] = []
 
         for child in self.children {
-            remove(child: child)
+            guard remove(child: child) else { continue }
             children.append(child)
         }
 
@@ -385,7 +385,7 @@ extension List.Item {
         var children: [Node] = []
 
         for child in self.children {
-            remove(child: child)
+            guard remove(child: child) else { continue }
             children.append(child)
         }
 

--- a/Sources/CommonMark/Supporting Types/Children.swift
+++ b/Sources/CommonMark/Supporting Types/Children.swift
@@ -135,8 +135,7 @@ extension ContainerOfBlocks {
     @discardableResult
     public func remove(child: Block & Node) -> Bool {
         guard child.parent == self else { return false }
-        cmark_node_unlink(child.cmark_node)
-        child.managed = true
+        child.unlink()
         return true
     }
 }
@@ -232,8 +231,7 @@ extension ContainerOfInlineElements {
     @discardableResult
     public func remove(child: Inline & Node) -> Bool {
         guard child.parent == self else { return false }
-        cmark_node_unlink(child.cmark_node)
-        child.managed = true
+        child.unlink()
         return true
     }
 }
@@ -318,8 +316,7 @@ extension List {
     @discardableResult
     public func remove(child: Item) -> Bool {
          guard child.parent == self else { return false }
-         cmark_node_unlink(child.cmark_node)
-         child.managed = true
+         child.unlink()
          return true
     }
 }
@@ -404,8 +401,7 @@ extension List.Item {
     @discardableResult
     public func remove(child: Node) -> Bool {
         guard child.parent == self else { return false }
-        cmark_node_unlink(child.cmark_node)
-        child.managed = true
+        child.unlink()
         return true
     }
 }

--- a/Sources/CommonMark/Supporting Types/Children.swift
+++ b/Sources/CommonMark/Supporting Types/Children.swift
@@ -58,7 +58,13 @@ extension Document: ContainerOfBlocks {}
 extension BlockQuote: ContainerOfBlocks {}
 
 extension ContainerOfBlocks {
-    /// The block's children.
+    /**
+     The block elements contained by the node.
+
+     - Important: The returned child nodes are valid only during the lifetime of their parent.
+                  Use the `removeChildren()` method to detach and access children
+                  beyond the lifetime of their parent.
+     */
     public var children: [Block & Node] {
         get {
             return Children(of: self).compactMap { $0 as? Block & Node }
@@ -73,18 +79,6 @@ extension ContainerOfBlocks {
                 append(child: child)
             }
         }
-    }
-
-    /// Removes the block's children and returns them.
-    public func drain() -> [Block & Node] {
-        var children: [Block & Node] = []
-
-        for child in self.children {
-            guard remove(child: child) else { continue }
-            children.append(child)
-        }
-
-        return children
     }
 
     /**
@@ -151,6 +145,23 @@ extension ContainerOfBlocks {
 
         return true
     }
+
+    /**
+     Removes and returns the node's children.
+
+     - Returns: An array of block structure elements.
+     */
+    @discardableResult
+    public func removeChildren() -> [Block & Node] {
+        var children: [Block & Node] = []
+
+        for child in self.children {
+            guard remove(child: child) else { continue }
+            children.append(child)
+        }
+
+        return children
+    }
 }
 
 // MARK: -
@@ -167,7 +178,13 @@ extension Emphasis: ContainerOfInlineElements {}
 extension Link: ContainerOfInlineElements {}
 
 extension ContainerOfInlineElements {
-    /// The block's children.
+    /**
+     The inline elements contained by the node.
+
+     - Important: The returned child nodes are valid only during the lifetime of their parent.
+                  Use the `removeChildren()` method to detach and access children
+                  beyond the lifetime of their parent.
+     */
     public var children: [Inline & Node] {
         get {
             return Children(of: self).compactMap { $0 as? Inline & Node }
@@ -182,18 +199,6 @@ extension ContainerOfInlineElements {
                 append(child: child)
             }
         }
-    }
-
-    /// Removes the block's children and returns them.
-    public func drain() -> [Inline & Node] {
-        var children: [Inline & Node] = []
-
-        for child in self.children {
-            guard remove(child: child) else { continue }
-            children.append(child)
-        }
-
-        return children
     }
 
     /**
@@ -260,12 +265,35 @@ extension ContainerOfInlineElements {
 
         return true
     }
+
+    /**
+     Removes and returns the node's children.
+
+     - Returns: An array of inline content elements.
+     */
+    @discardableResult
+    public func removeChildren() -> [Inline & Node] {
+        var children: [Inline & Node] = []
+
+        for child in self.children {
+            guard remove(child: child) else { continue }
+            children.append(child)
+        }
+
+        return children
+    }
 }
 
 // MARK: -
 
 extension List {
-    /// The block's children.
+    /**
+     The list's items.
+
+     - Important: The returned child nodes are valid only during the lifetime of their parent.
+                  Use the `removeChildren()` method to detach and access children
+                  beyond the lifetime of their parent.
+     */
     public var children: [Item] {
         get {
             return Children(of: self).compactMap { $0 as? Item }
@@ -280,18 +308,6 @@ extension List {
                 append(child: child)
             }
         }
-    }
-
-    /// Removes the block's children and returns them.
-    public func drain() -> [Item] {
-        var children: [Item] = []
-
-        for child in self.children {
-            guard remove(child: child) else { continue }
-            children.append(child)
-        }
-
-        return children
     }
 
     /**
@@ -358,12 +374,35 @@ extension List {
 
         return true
     }
+
+    /**
+     Removes and returns the list's items.
+
+     - Returns: An array of list items.
+     */
+    @discardableResult
+    public func removeChildren() -> [Item] {
+        var children: [Item] = []
+
+        for child in self.children {
+            guard remove(child: child) else { continue }
+            children.append(child)
+        }
+
+        return children
+    }
 }
 
 // MARK: -
 
 extension List.Item {
-    /// The list item's children.
+    /**
+     The elements contained by the list item.
+
+     - Important: The returned child nodes are valid only during the lifetime of their parent.
+                  Use the `removeChildren()` method to detach and access children
+                  beyond the lifetime of their parent.
+     */
     public var children: [Node] {
         get {
             return Children(of: self).map { $0 }
@@ -378,18 +417,6 @@ extension List.Item {
                 append(child: child)
             }
         }
-    }
-
-    /// Removes the block's children and returns them.
-    public func drain() -> [Node] {
-        var children: [Node] = []
-
-        for child in self.children {
-            guard remove(child: child) else { continue }
-            children.append(child)
-        }
-
-        return children
     }
 
     /**
@@ -455,5 +482,21 @@ extension List.Item {
         child.unlink()
 
         return true
+    }
+
+    /**
+     Removes and returns the list item's children.
+
+     - Returns: An array of nodes.
+     */
+    public func removeChildren() -> [Node] {
+        var children: [Node] = []
+
+        for child in self.children {
+            guard remove(child: child) else { continue }
+            children.append(child)
+        }
+
+        return children
     }
 }

--- a/Sources/CommonMarkBuilder/Fragment.swift
+++ b/Sources/CommonMarkBuilder/Fragment.swift
@@ -8,7 +8,13 @@ public struct Fragment {
     }
 
     public init(@StringBuilder _ builder: () -> String) {
-        self.init(children: (try? Document(builder()).children) ?? [])
+        let document = try? Document(builder())
+        // We need to unlink the children from `document`
+        // so that they can outlive it, or we end up with dangling pointers.
+        // The easiest way to accomplish this is to use `drain()`,
+        // which removes the children from their parent before returning them:
+        let children = document?.drain() ?? []
+        self.init(children: children)
     }
 
     public init(@CommonMarkBuilder _ builder: () -> BlockConvertible) {

--- a/Sources/CommonMarkBuilder/Fragment.swift
+++ b/Sources/CommonMarkBuilder/Fragment.swift
@@ -9,11 +9,8 @@ public struct Fragment {
 
     public init(@StringBuilder _ builder: () -> String) {
         let document = try? Document(builder())
-        // We need to unlink the children from `document`
-        // so that they can outlive it, or we end up with dangling pointers.
-        // The easiest way to accomplish this is to use `drain()`,
-        // which removes the children from their parent before returning them:
-        let children = document?.drain() ?? []
+        // Unlink the children from the document node to prevent dangling pointers to the parent.
+        let children = document?.removeChildren() ?? []
         self.init(children: children)
     }
 

--- a/Tests/CommonMarkTests/DocumentCodingTests.swift
+++ b/Tests/CommonMarkTests/DocumentCodingTests.swift
@@ -9,8 +9,8 @@ final class DocumentCodingTests: XCTestCase {
         let encoded = try JSONEncoder().encode([document])
         let decoded = try JSONDecoder().decode([Document].self, from: encoded)[0]
 
-        let expected = document.render(format: .html)
-        let actual = decoded.render(format: .html)
+        let expected = document.render(format: .commonmark)
+        let actual = decoded.render(format: .commonmark)
 
         XCTAssertEqual(expected, actual)
     }
@@ -24,8 +24,8 @@ final class DocumentCodingTests: XCTestCase {
         let encoded = try JSONEncoder().encode([heading])
         let decoded = try JSONDecoder().decode([Heading].self, from: encoded)[0]
 
-        let expected = try Document(heading.description).render(format: .html)
-        let actual = try Document(decoded.description).render(format: .html)
+        let expected = try Document(heading.description).render(format: .commonmark)
+        let actual = try Document(decoded.description).render(format: .commonmark)
 
         XCTAssertEqual(expected, actual)
     }
@@ -40,8 +40,8 @@ final class DocumentCodingTests: XCTestCase {
         let encoded = try JSONEncoder().encode([link])
         let decoded = try JSONDecoder().decode([Link].self, from: encoded)[0]
 
-        let expected = try Document(link.description).render(format: .html)
-        let actual = try Document(decoded.description).render(format: .html)
+        let expected = try Document(link.description).render(format: .commonmark)
+        let actual = try Document(decoded.description).render(format: .commonmark)
 
         XCTAssertEqual(expected, actual)
     }

--- a/Tests/CommonMarkTests/DocumentCodingTests.swift
+++ b/Tests/CommonMarkTests/DocumentCodingTests.swift
@@ -7,10 +7,10 @@ final class DocumentCodingTests: XCTestCase {
 
         // Workaround for "Top-level Document encoded as string JSON fragment."
         let encoded = try JSONEncoder().encode([document])
-        let decoded = try JSONDecoder().decode([Document].self, from: encoded)
+        let decoded = try JSONDecoder().decode([Document].self, from: encoded)[0]
 
         let expected = document.render(format: .html)
-        let actual = decoded[0].render(format: .html)
+        let actual = decoded.render(format: .html)
 
         XCTAssertEqual(expected, actual)
     }
@@ -22,10 +22,10 @@ final class DocumentCodingTests: XCTestCase {
 
         // Workaround for "Top-level Heading encoded as string JSON fragment."
         let encoded = try JSONEncoder().encode([heading])
-        let decoded = try JSONDecoder().decode([Heading].self, from: encoded)
+        let decoded = try JSONDecoder().decode([Heading].self, from: encoded)[0]
 
         let expected = try Document(heading.description).render(format: .html)
-        let actual = try Document(decoded[0].description).render(format: .html)
+        let actual = try Document(decoded.description).render(format: .html)
 
         XCTAssertEqual(expected, actual)
     }
@@ -38,10 +38,10 @@ final class DocumentCodingTests: XCTestCase {
 
         // Workaround for "Top-level Link encoded as string JSON fragment."
         let encoded = try JSONEncoder().encode([link])
-        let decoded = try JSONDecoder().decode([Link].self, from: encoded)
+        let decoded = try JSONDecoder().decode([Link].self, from: encoded)[0]
 
         let expected = try Document(link.description).render(format: .html)
-        let actual = try Document(decoded[0].description).render(format: .html)
+        let actual = try Document(decoded.description).render(format: .html)
 
         XCTAssertEqual(expected, actual)
     }

--- a/Tests/CommonMarkTests/DocumentParsingTests.swift
+++ b/Tests/CommonMarkTests/DocumentParsingTests.swift
@@ -35,6 +35,26 @@ final class DocumentParsingTests: XCTestCase {
         XCTAssertEqual(paragraph.parent, document)
     }
 
+    // https://github.com/SwiftDocOrg/CommonMark/issues/19
+    func testLinkParsing() throws {
+        let document = try Document(#"""
+        [Universal Declaration of Human Rights](https://www.un.org/en/universal-declaration-human-rights/ "View full version")
+        """#)
+
+        let paragraph = document.children[0] as! Paragraph
+        XCTAssertEqual(paragraph.children.count, 1)
+        XCTAssertEqual(paragraph.parent, document)
+
+        let link = paragraph.children[0] as! Link
+        XCTAssertEqual(link.urlString, "https://www.un.org/en/universal-declaration-human-rights/")
+        XCTAssertEqual(link.title, "View full version")
+        XCTAssertEqual(link.parent, paragraph)
+
+        let text = link.children[0] as! Text
+        XCTAssertEqual(text.literal, "Universal Declaration of Human Rights")
+        XCTAssertEqual(text.parent, link)
+    }
+
     // https://github.com/SwiftDocOrg/CommonMark/issues/1
     func testInvalidRange() throws {
         let commonmark = "* #"

--- a/Tests/CommonMarkTests/DocumentRenderingTests.swift
+++ b/Tests/CommonMarkTests/DocumentRenderingTests.swift
@@ -19,6 +19,24 @@ final class DocumentRenderingTests: XCTestCase {
         XCTAssertEqual(document.render(format: .commonmark, width: 60), expected)
     }
 
+    // https://github.com/SwiftDocOrg/CommonMark/issues/19
+    func testLinkCommonMarkRendering() throws {
+        let document = try Document(#"""
+        [Universal Declaration of Human Rights](https://www.un.org/en/universal-declaration-human-rights/ "View full version")
+        """#)
+
+        let paragraph = document.children[0] as! Paragraph
+        let link = paragraph.children[0] as! Link
+
+        let actual = link.render(format: .commonmark)
+        let expected = #"""
+        [Universal Declaration of Human Rights](https://www.un.org/en/universal-declaration-human-rights/ "View full version")
+
+        """#
+
+        XCTAssertEqual(actual, expected)
+    }
+
     func testNodeCommonMarkRendering() throws {
         let document = try Document(Fixtures.udhr)
 


### PR DESCRIPTION
Fixes a memory leak in `Document.init(_:options:)`, as well as a memory safety bug (dangling pointers) caused by an erroneous implementation of `Node.init(from:)`, which was hidden by the memory leak.

Due to the memory leak caused by never setting `self.managed = true` on decoding of `Document` the dangling pointers produced by `Node.init(from:)` did not cause a crash before.

The previous implementation simply decoded a `Document` and then pulled its root node out without properly unlinking it from the document and re-assigning the memory management duties. So when the `Document` gets deinitialized any pointers to its contents are no longer valid (unless the document leaks its contents, which it did).

Fixes https://github.com/SwiftDocOrg/CommonMark/issues/19