### PR TITLE
Update to libcmark 0.29.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/SwiftDocOrg/swift-cmark.git",
         "state": {
           "branch": null,
-          "revision": "2a766030bee955b4806044fd7aca1b6884475138",
-          "version": "0.28.3+20200110.2a76603"
+          "revision": "9c8096a23f44794bde297452d87c455fc4f76d42",
+          "version": "0.29.0+20210102.9c8096a"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/SwiftDocOrg/swift-cmark.git", from: Version(0, 28, 3, prereleaseIdentifiers: [], buildMetadataIdentifiers: ["20200207", "1168665"])),
+        .package(url: "https://github.com/SwiftDocOrg/swift-cmark.git", from: Version(0, 29, 0, prereleaseIdentifiers: [], buildMetadataIdentifiers: ["20210102", "9c8096a"])),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Tests/CommonMarkTests/CommonMarkTests.swift
+++ b/Tests/CommonMarkTests/CommonMarkTests.swift
@@ -4,7 +4,7 @@ import CommonMark
 final class CommonMarkTests: XCTestCase {
     func testCommonMarkVersion() {
         XCTAssertEqual(CommonMark.version.major, 0)
-        XCTAssertEqual(CommonMark.version.minor, 28)
-        XCTAssertEqual(CommonMark.version.patch, 3)
+        XCTAssertEqual(CommonMark.version.minor, 29)
+        XCTAssertEqual(CommonMark.version.patch, 0)
     }
 }


### PR DESCRIPTION
Synchronizes with latest from Apple's upstream swift-cmark, which notably includes a change that may resolve the failing test case in #22:

https://github.com/SwiftDocOrg/swift-cmark/commit/1168665f6b36be747ffe6b7b90bc54cfc17f42b7#diff-8a84f48458df6eb6274fc1f0eb3c58d7c8e295ed0873323f99b9567202acc392L146-L149

```diff
static bool is_autolink(cmark_node *node) {
     return false;
   }
   cmark_consolidate_text_nodes(link_text);
-  if (strcmp((const char *)url, "mailto:") == 0) {
+  if (strncmp((const char *)url, "mailto:", 7) == 0) {
     url += 7;
   }
-  return strcmp((const char *)url, (char *)link_text->data) == 0;
+  return link_text->data != NULL &&
+         strcmp((const char *)url, (char *)link_text->data) == 0;
 }
```