### PR TITLE
Fix the changelog to reflect the actual version history.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added support for the visitor pattern,
   by adding `protocol Visitor`/`protocol Visitable` & `enum VisitorContinueKind`.
-
+  #13 by @regexident.
 ### Fixed
 
 - Fixed document parsing options.

--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.5.0] - 2021-01-14
 
+### Added
+
+- Added support for the visitor pattern,
+  by adding `protocol Visitor`/`protocol Visitable` & `enum VisitorContinueKind`.
+
 ### Fixed
 
 - Fixed document parsing options.
@@ -25,8 +30,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added support for the visitor pattern,
-  by adding `protocol Visitor`/`protocol Visitable` & `enum VisitorContinueKind`.
 - Added a changelog.
   #17 by @mattt.
 


### PR DESCRIPTION
When the changelog was updated in commit 1198cc74b8a6d05f5f06d38de319852840c1ac52, the change was added to the wrong section. So when #13 was merged, the changelog did not reflect the actual scope of version `0.4.0` anymore.