### PR TITLE
Simplify Hashable implementation

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -17,6 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed documentation for `List`.
   #29 by @mattt.
 
+### Changed
+
+- Changed implementation of `Hashable` conformance for `Node`.
+  Previously the hash value of a node was computed from its content.
+  Now it's computed from the opaque cmark pointer.
+  #30 by @Lukas-Stuehrk.
+
 ## [0.5.0] - 2021-01-14
 
 ### Added

--- a/Sources/CommonMark/Nodes/Node.swift
+++ b/Sources/CommonMark/Nodes/Node.swift
@@ -326,14 +326,7 @@ extension Node: Equatable {
 
 extension Node: Hashable {
     public func hash(into hasher: inout Hasher) {
-        let cString = cmark_render_commonmark(cmark_node, 0, 0)!
-
-        defer {
-            free(cString)
-        }
-
-        hasher.combine(cmark_node_get_type(cmark_node).rawValue)
-        hasher.combine(cString)
+        hasher.combine(cmark_node)
     }
 }
 

--- a/Tests/CommonMarkTests/NodeTests.swift
+++ b/Tests/CommonMarkTests/NodeTests.swift
@@ -1,0 +1,74 @@
+import XCTest
+import CommonMark
+
+final class NodeTests: XCTestCase {
+
+    // MARK: - Equality
+
+    func testNodesEquality() {
+        let firstNode = Paragraph(text: #"""
+        All human beings are born free and equal in dignity and rights.
+        They are endowed with reason and conscience
+        and should act towards one another in a spirit of brotherhood.
+        """#, replacingNewLinesWithBreaks: true)
+        let secondNode = Paragraph(text: #"""
+        All human beings are born free and equal in dignity and rights.
+        They are endowed with reason and conscience
+        and should act towards one another in a spirit of brotherhood.
+        """#, replacingNewLinesWithBreaks: true)
+
+        XCTAssertNotEqual(firstNode, secondNode)
+        XCTAssertEqual(firstNode, firstNode)
+        XCTAssertEqual(secondNode, secondNode)
+    }
+
+    // MARK: - Hashable
+
+    func testNodesHashable() {
+        let text = #"""
+        All human beings are born free and equal in dignity and rights.
+        They are endowed with reason and conscience
+        and should act towards one another in a spirit of brotherhood.
+        """#
+        
+        let firstNode = Paragraph(text: "\(text)", replacingNewLinesWithBreaks: true)
+        let secondNode = Paragraph(text: "\(text)", replacingNewLinesWithBreaks: true)
+
+        var map = [Node: String]()
+        map[firstNode] = "first"
+        map[secondNode] = "second"
+
+        XCTAssertEqual(map[firstNode], "first")
+        XCTAssertEqual(map[secondNode], "second")
+    }
+
+    func testHashValueConsistentAfterModification() {
+        let node = Text(literal: "Some Text")
+
+        var map = [Node: String]()
+        map[node] = "first mapping"
+        map[node] = "second mapping"
+
+        XCTAssertEqual(map[node], "second mapping")
+    }
+    
+    func testHashValueConsistentAfterNodeIsModified() {
+        let paragraph = Paragraph(text: #"""
+        All human beings are born free and equal in dignity and rights.
+        They are endowed with reason and conscience
+        """#, replacingNewLinesWithBreaks: true)
+        var nodes = Set<Node>()
+        nodes.insert(paragraph)
+
+        paragraph.append(child: Text(literal: "and should act towards one another in a spirit of brotherhood."))
+
+        XCTAssertTrue(nodes.contains(paragraph))
+        XCTAssertEqual(paragraph.description,
+        #"""
+        All human beings are born free and equal in dignity and rights.
+        They are endowed with reason and conscience
+        and should act towards one another in a spirit of brotherhood.
+
+        """#)
+    }
+}


### PR DESCRIPTION
With the current implementation, nodes with the same type and contents have the same hash. But then in the `Equatable` implementation, we check for the same `cmark_node`. Therefore only `Node` instances for the same `cmark_node` can be used as the key in a dictionary or set, making the `Hashable` implementation more complicated than it needs to be.

With this change we also use the `cmark_node` for the `Hashable` implementation.